### PR TITLE
Prevent fatal error when an item does not have a delivery type

### DIFF
--- a/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
+++ b/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
@@ -63,7 +63,7 @@ class Digitalproduct extends BaseModule {
 
         foreach ($items as $item) {
             $deliveryType = $item->getOne('DeliveryType');
-            if ($deliveryType->get('shipment_type') !== 'DigitalproductOrderShipment') {
+            if (!$deliveryType || $deliveryType->get('shipment_type') !== 'DigitalproductOrderShipment') {
                 continue;
             }
 


### PR DESCRIPTION
Adding a fixed-price coupon to an order creates an order item without a delivery type, and causes a fatal error in the digital product module.

```
PHP Fatal error: Uncaught Error: Call to a member function get() on null in core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php:66
Stack trace:
#0 core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php(87): RogueClarity\Digitalproduct\Modules\Digitalproduct->getOrderDigitalItems(Object(comSessionCartOrder_mysql))
#1 core/components/commerce/vendor/symfony/event-dispatcher/EventDispatcher.php(184): RogueClarity\Digitalproduct\Modules\Digitalproduct->addCheckoutPlaceholders(Object(modmore\Commerce\Events\Checkout), 'core.checkout.a...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#2 core/components/commerce/vendor/symfony/event-dispatcher/EventDispatcher.php(46): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'core.checkout.a...', Object(modmore\Commerce\Events\Checkout))
#3 core/components/commerce/src/Frontend/Checkout/Pro in core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php on line 66
```
