### PR TITLE
Add placeholders via EVENT_ORDER_PLACEHOLDERS event

### DIFF
--- a/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
+++ b/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
@@ -34,8 +34,11 @@ class Digitalproduct extends BaseModule {
         $this->adapter->loadLexicon('commerce_digitalproduct:default');
 
         $dispatcher->addListener(\Commerce::EVENT_CHECKOUT_AFTER_STEP, [$this, 'addCheckoutPlaceholders']);
-        $dispatcher->addListener(\Commerce::EVENT_ORDER_PLACEHOLDERS, [$this, 'addGetOrderPlaceholders']);
         $dispatcher->addListener(\Commerce::EVENT_ORDER_MESSAGE_PLACEHOLDERS, [$this, 'addMessagePlaceholders']);
+        // Check if the event exists (Requires Commerce 1.3+)
+        if(defined('\Commerce::EVENT_ORDER_PLACEHOLDERS')) {
+            $dispatcher->addListener(\Commerce::EVENT_ORDER_PLACEHOLDERS, [$this, 'addGetOrderPlaceholders']);
+        }
 
         // Add the xPDO package, so Commerce can detect the derivative classes
         $root = dirname(dirname(__DIR__));
@@ -69,7 +72,8 @@ class Digitalproduct extends BaseModule {
         $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
     }
 
-    public function addGetOrderPlaceholders(OrderPlaceholders $event) {
+    public function addGetOrderPlaceholders(OrderPlaceholders $event): void
+    {
         $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
     }
 

--- a/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
+++ b/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
@@ -69,6 +69,10 @@ class Digitalproduct extends BaseModule {
         $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
     }
 
+    public function addGetOrderPlaceholders(OrderPlaceholders $event) {
+        $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
+    }
+
     public function getModuleConfiguration(\comModule $module)
     {
         $fields = [];
@@ -108,35 +112,5 @@ class Digitalproduct extends BaseModule {
         }
 
         return $output;
-    }
-
-    public function addGetOrderPlaceholders(OrderPlaceholders $event) {
-        $order = $event->getOrder();
-
-        // If there are no digital products, we can stop here.
-        if(!$order->getProperty('has_digital_products')) {
-            return;
-        }
-
-        $c = $this->adapter->newQuery(\Digitalproduct::class);
-        $c->where([
-            'order' => $order->get('id'),
-        ]);
-
-        /** @var \Digitalproduct[] $digitalProducts */
-        $digitalProducts = $this->adapter->getIterator(\Digitalproduct::class, $c);
-        $phs = [];
-        foreach ($digitalProducts as $digitalProduct) {
-
-            $data = $digitalProduct->toArray();
-
-            /** @var \DigitalproductFile[] $files */
-            $files = $digitalProduct->getMany('File');
-            foreach ($files as $file) {
-                $data['files'][] = $file->toArray();
-            }
-            $phs[] = $data;
-        }
-        $event->setPlaceholder('digital_products',$phs);
     }
 }


### PR DESCRIPTION
Example twig code to display the links via the get_order snippet could be:

`frontend/account/order-detail.twig - line 49` 
```
{% if order.digitalProducts|length > 0 %}
    {% for digitalProduct in order.digitalProducts %}
        {% if digitalProduct.resources|length > 0 %}
            <td class="c-order-item-digital-product-resources">
            {% for resource in digitalProduct.resources %}
                <a href="[[~[[++commerce_digitalproduct.download_resource]]? &scheme=`full` &secret=`{{ resource.secret }}`]]">{{ resource.name }}</a>
            {% endfor %}
            </td>
        {% endif %}

        {% if digitalProduct.files|length > 0 %}
            <td class="c-order-item-digital-product-files">
            {% for file in digitalProduct.files %}
                <a href="[[~[[++commerce_digitalproduct.download_resource]]? &scheme=`full` &secret=`{{ file.secret }}`]]">{{ file.name }}</a>
            {% endfor %}
            </td>
        {% endif %}
    {% endfor %}
{% endif %}
```