### PR TITLE
Usergroup fix

### DIFF
--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/digitalproductordershipment.class.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/digitalproductordershipment.class.php
@@ -131,6 +131,11 @@ class DigitalproductOrderShipment extends comOrderShipment
 
             $product = $orderItem->getProduct();
 
+            // Joins the user to the product's usergroup if they are logged in
+            if ($user && $product->getProperty('usergroup')) {
+                $user->joinGroup((int)$product->getProperty('usergroup'));
+            }
+
             // Add the product to the digitalproduct table for tracking
             /** @var Digitalproduct $digitalProduct */
             $digitalProduct = $this->adapter->newObject('Digitalproduct', [
@@ -152,11 +157,6 @@ class DigitalproductOrderShipment extends comOrderShipment
                 'all' => $all,
                 'product' => $product->toArray()
             ];
-
-            // Joins the user to the product's usergroup if they are logged in
-            if ($user && $product->getProperty('usergroup')) {
-                $user->joinGroup((int)$product->getProperty('usergroup'));
-            }
         }
 
         return $output;

--- a/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
+++ b/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
@@ -34,8 +34,11 @@ class Digitalproduct extends BaseModule {
         $this->adapter->loadLexicon('commerce_digitalproduct:default');
 
         $dispatcher->addListener(\Commerce::EVENT_CHECKOUT_AFTER_STEP, [$this, 'addCheckoutPlaceholders']);
-        $dispatcher->addListener(\Commerce::EVENT_ORDER_PLACEHOLDERS, [$this, 'addGetOrderPlaceholders']);
         $dispatcher->addListener(\Commerce::EVENT_ORDER_MESSAGE_PLACEHOLDERS, [$this, 'addMessagePlaceholders']);
+        // Check if the event exists (Requires Commerce 1.3+)
+        if(defined('\Commerce::EVENT_ORDER_PLACEHOLDERS')) {
+            $dispatcher->addListener(\Commerce::EVENT_ORDER_PLACEHOLDERS, [$this, 'addGetOrderPlaceholders']);
+        }
 
         // Add the xPDO package, so Commerce can detect the derivative classes
         $root = dirname(dirname(__DIR__));
@@ -69,7 +72,8 @@ class Digitalproduct extends BaseModule {
         $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
     }
 
-    public function addGetOrderPlaceholders(OrderPlaceholders $event) {
+    public function addGetOrderPlaceholders(OrderPlaceholders $event): void
+    {
         $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
     }
 

--- a/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
+++ b/core/components/commerce_digitalproduct/src/Modules/Digitalproduct.php
@@ -69,6 +69,10 @@ class Digitalproduct extends BaseModule {
         $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
     }
 
+    public function addGetOrderPlaceholders(OrderPlaceholders $event) {
+        $event->setPlaceholder('digitalProducts', $this->getPlaceholders($event->getOrder()));
+    }
+
     public function getModuleConfiguration(\comModule $module)
     {
         $fields = [];
@@ -108,35 +112,5 @@ class Digitalproduct extends BaseModule {
         }
 
         return $output;
-    }
-
-    public function addGetOrderPlaceholders(OrderPlaceholders $event) {
-        $order = $event->getOrder();
-
-        // If there are no digital products, we can stop here.
-        if(!$order->getProperty('has_digital_products')) {
-            return;
-        }
-
-        $c = $this->adapter->newQuery(\Digitalproduct::class);
-        $c->where([
-            'order' => $order->get('id'),
-        ]);
-
-        /** @var \Digitalproduct[] $digitalProducts */
-        $digitalProducts = $this->adapter->getIterator(\Digitalproduct::class, $c);
-        $phs = [];
-        foreach ($digitalProducts as $digitalProduct) {
-
-            $data = $digitalProduct->toArray();
-
-            /** @var \DigitalproductFile[] $files */
-            $files = $digitalProduct->getMany('File');
-            foreach ($files as $file) {
-                $data['files'][] = $file->toArray();
-            }
-            $phs[] = $data;
-        }
-        $event->setPlaceholder('digital_products',$phs);
     }
 }


### PR DESCRIPTION
When a product is set to add a user to a usergroup on purchase, make sure the user is added before the resources are loaded or it will fail due to ACLs.