### PR TITLE
Create product bundles that can contain both physical and digital products

### DIFF
--- a/_bootstrap/index.php
+++ b/_bootstrap/index.php
@@ -131,11 +131,9 @@ $modulePath = $componentPath . '/core/components/commerce_digitalproduct/src/Mod
 $commerce->loadModulesFromDirectory($modulePath, 'modmore\\Commerce_DigitalProduct\\Modules\\', $modulePath);
 
 $modx->addPackage('commerce_digitalproduct', $componentPath . '/core/components/commerce_digitalproduct/model/');
-
 $manager = $modx->getManager();
 $manager->createObjectContainer('Digitalproduct');
 $manager->createObjectContainer('DigitalproductFile');
-$manager->createObjectContainer('DigitalProductBundleData');
 
 // Clear the cache
 $modx->cacheManager->refresh();

--- a/_bootstrap/index.php
+++ b/_bootstrap/index.php
@@ -131,9 +131,11 @@ $modulePath = $componentPath . '/core/components/commerce_digitalproduct/src/Mod
 $commerce->loadModulesFromDirectory($modulePath, 'modmore\\Commerce_DigitalProduct\\Modules\\', $modulePath);
 
 $modx->addPackage('commerce_digitalproduct', $componentPath . '/core/components/commerce_digitalproduct/model/');
+
 $manager = $modx->getManager();
 $manager->createObjectContainer('Digitalproduct');
 $manager->createObjectContainer('DigitalproductFile');
+$manager->createObjectContainer('DigitalProductBundleData');
 
 // Clear the cache
 $modx->cacheManager->refresh();

--- a/_build/build.schema.php
+++ b/_build/build.schema.php
@@ -85,9 +85,6 @@ EOD;
 
 $generator->parseSchema($sources['schema'] . 'commerce_digitalproduct.mysql.schema.xml', $sources['model']);
 
-$manager->createObjectContainer('Digitalproduct');
-$manager->createObjectContainer('DigitalproductFile');
-
 $mtime= microtime();
 $mtime= explode(" ", $mtime);
 $mtime= $mtime[1] + $mtime[0];

--- a/core/components/commerce_digitalproduct/lexicon/en/default.inc.php
+++ b/core/components/commerce_digitalproduct/lexicon/en/default.inc.php
@@ -11,6 +11,10 @@ $_lang['commerce.DigitalproductOrderShipment'] = 'Digital Shipment';
 $_lang['commerce.DigitalproductProduct'] = 'Digital Product';
 $_lang['commerce.add_DigitalproductProduct'] = 'Add Digital Product';
 
+// Bundle
+$_lang['commerce.DigitalProductBundle'] = 'Digital Product Bundle';
+$_lang['commerce.add_DigitalProductBundle'] = 'Add Digital Product Bundle';
+
 // Tabs
 $_lang['commerce_digitalproduct.product_tab'] = 'Digital';
 
@@ -33,6 +37,12 @@ $_lang['commerce_digitalproduct.files_desc'] = 'Files that may be sold as a down
 
 $_lang['commerce_digitalproduct.resource_display_name'] = 'Display Name (shows to customer)';
 $_lang['commerce_digitalproduct.url'] = 'URL to File';
+
+$_lang['commerce_digitalproduct.primary_delivery_type'] = 'Primary Delivery Type';
+$_lang['commerce_digitalproduct.secondary_delivery_type'] = 'Secondary Delivery Type (Optional)';
+$_lang['commerce_digitalproduct.primary_delivery_type.field_desc'] = '<b>Required:</b> If there are both physical and digital products in the bundle, set the physical delivery type here. If not, set the digital delivery type.';
+$_lang['commerce_digitalproduct.secondary_delivery_type.field_desc'] = '<b>Optional:</b> If the primary delivery type is physical, set the digital delivery type here.';
+$_lang['commerce_digitalproduct.no_secondary_delivery_type'] = 'No secondary delivery type';
 
 // Frontend
 $_lang['commerce_digitalproduct.pages'] = 'Pages';

--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/digitalproductbundle.class.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/digitalproductbundle.class.php
@@ -1,0 +1,42 @@
+<?php
+
+use modmore\Commerce\Admin\Widgets\Form\DeliveryTypeField;
+use modmore\Commerce_DigitalProduct\Admin\Widgets\Form\SecondaryDeliveryTypeField;
+
+/**
+ * Digitalproduct for Commerce.
+ *
+ * Copyright 2019 by Tony Klapatch <tony@klapatch.net>
+ *
+ * This file is meant to be used with Commerce by modmore. A valid Commerce license is required.
+ *
+ * @package commerce_digitalproduct
+ * @license See core/components/commerce_digitalproduct/docs/license.txt
+ */
+class DigitalProductBundle extends comProductBundle
+{
+    public function getModelFields()
+    {
+        $fields = parent::getModelFields();
+
+        foreach ($fields as $k => $field) {
+            if ($field instanceof DeliveryTypeField && $field->getName() === 'delivery_type') {
+                // Alter delivery type label and description
+                $field->setLabel($this->adapter->lexicon('commerce_digitalproduct.primary_delivery_type'));
+                $field->setDescription($this->adapter->lexicon('commerce_digitalproduct.primary_delivery_type.field_desc'));
+
+                // Add secondary delivery type (digital only)
+                array_splice( $fields, $k + 1, 0, [
+                    new SecondaryDeliveryTypeField($this->commerce, [
+                        'name' => 'properties[digital_bundle_delivery_type]',
+                        'label' => $this->adapter->lexicon('commerce_digitalproduct.secondary_delivery_type'),
+                        'description' => $this->adapter->lexicon('commerce_digitalproduct.secondary_delivery_type.field_desc'),
+                        'value' => $this->getProperty('digital_bundle_delivery_type'),
+                    ])
+                ]);
+            }
+        }
+
+        return $fields;
+    }
+}

--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/digitalproductproduct.class.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/digitalproductproduct.class.php
@@ -1,8 +1,5 @@
 <?php
 
-use modmore\Commerce\Admin\Widgets\Form\TextField;
-use modmore\Commerce\Admin\Widgets\Form\Tab;
-
 /**
  * Digitalproduct for Commerce.
  *

--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/metadata.mysql.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/metadata.mysql.php
@@ -1,6 +1,10 @@
 <?php
 
 $xpdo_meta_map = array (
+  'comProductBundle' => 
+  array (
+    0 => 'DigitalProductBundle',
+  ),
   'comProduct' => 
   array (
     0 => 'DigitalproductProduct',

--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/mysql/digitalproduct.map.inc.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/mysql/digitalproduct.map.inc.php
@@ -46,7 +46,7 @@ $xpdo_meta_map['Digitalproduct']= array (
       'null' => false,
       'default' => 0,
     ),
-    'bundle' =>
+    'bundle' => 
     array (
       'dbtype' => 'int',
       'attributes' => 'unsigned',

--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/mysql/digitalproductbundle.class.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/mysql/digitalproductbundle.class.php
@@ -1,0 +1,16 @@
+<?php
+require_once strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/digitalproductbundle.class.php';
+/**
+ * Digitalproduct for Commerce.
+ *
+ * Copyright 2019 by Tony Klapatch <tony@klapatch.net>
+ *
+ * This file is meant to be used with Commerce by modmore. A valid Commerce license is required.
+ *
+ * @package commerce_digitalproduct
+ * @license See core/components/commerce_digitalproduct/docs/license.txt
+ */
+class DigitalProductBundle_mysql extends DigitalProductBundle
+{
+
+}

--- a/core/components/commerce_digitalproduct/model/commerce_digitalproduct/mysql/digitalproductbundle.map.inc.php
+++ b/core/components/commerce_digitalproduct/model/commerce_digitalproduct/mysql/digitalproductbundle.map.inc.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Digitalproduct for Commerce.
+ *
+ * Copyright 2019 by Tony Klapatch <tony@klapatch.net>
+ *
+ * This file is meant to be used with Commerce by modmore. A valid Commerce license is required.
+ *
+ * @package commerce_digitalproduct
+ * @license See core/components/commerce_digitalproduct/docs/license.txt
+ */
+
+$xpdo_meta_map['DigitalProductBundle']= array (
+  'package' => 'commerce_digitalproduct',
+  'version' => '1.1',
+  'extends' => 'comProductBundle',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/components/commerce_digitalproduct/model/schema/commerce_digitalproduct.mysql.schema.xml
+++ b/core/components/commerce_digitalproduct/model/schema/commerce_digitalproduct.mysql.schema.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model package="commerce_digitalproduct" baseClass="comSimpleObject" platform="mysql" defaultEngine="InnoDB" version="1.1">
+    <object class="DigitalProductBundle" extends="comProductBundle" />
     <object class="DigitalproductProduct" extends="comProduct" />
     <object class="DigitalproductOrderShipment" extends="comOrderShipment" />
 

--- a/core/components/commerce_digitalproduct/src/Admin/Widgets/Form/SecondaryDeliveryTypeField.php
+++ b/core/components/commerce_digitalproduct/src/Admin/Widgets/Form/SecondaryDeliveryTypeField.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace modmore\Commerce_DigitalProduct\Admin\Widgets\Form;
+
+use modmore\Commerce\Admin\Widgets\Form\DeliveryTypeField;
+
+class SecondaryDeliveryTypeField extends DeliveryTypeField
+{
+    public function getDeliveryTypes()
+    {
+        $c = $this->adapter->newQuery('comDeliveryType');
+        $c->where([
+            'removed' => false,
+            'shipment_type' => 'DigitalproductOrderShipment',
+        ]);
+        $c->sortby('name');
+
+        $this->options[] = [
+            'value' => 0,
+            'label' => $this->adapter->lexicon('commerce_digitalproduct.no_secondary_delivery_type')
+        ];
+
+        foreach ($this->adapter->getIterator('comDeliveryType', $c) as $delType) {
+            $this->options[] = [
+                'value' => $delType->get('id'),
+                'label' => $delType->get('name')
+            ];
+        }
+    }
+}


### PR DESCRIPTION
Experimental!

The new `DigitalProductBundle` extends `comProductBundle` and adds a secondary (digital) delivery type field.

If only using digital products, ignore the secondary field. But if using both physical and digital, physical delivery type should go in the primary field, and digital in the secondary. 

The second delivery type is not actually creating another shipment, it's just parsing the digital products, storing the records and adding values to their placeholders. 

In the order detail screen, products will still be grouped in the single bundle in the single shipment.